### PR TITLE
Refactor SAN handling, add permanentIdentifier to the SAN attributes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,26 @@
+version: "2"
+checks:
+  # Go returns 'error's rather than throwing exceptions, so the safer the code the more errors are returned.
+  # To avoid deeply nested if-statements we generally use guard clauses as recommended by Martin Fowler.
+  # Guard statements are if-statements that, as early as possible, check conditions and return if failed. They improve readability
+  # over nested if-statements. This however leads to many return statements which can't be avoided, so we'll disable the max. exit points check.
+  return-statements:
+    enabled: false
+exclude_patterns:
+  - "**/generated.go"
+  - "**/test/**/*.go"
+  - "**/test.go"
+  - "**/*_test.go"
+  - "**/test*.go"
+  - "**/mock/**/*.go"
+  - "**/mock.go"
+  - "**/*_mock.go"
+  - "docs/**/*.go"
+  - "codegen/**/*.go"
+  - "**/*.pb.go"
+  - "e2e-tests/**/*.go"
+plugins:
+  gofmt:
+    enabled: true
+  govet:
+    enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pem
 uzi-did-x509-issuer
+c.out

--- a/did_x509/did_x509_test.go
+++ b/did_x509/did_x509_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"github.com/nuts-foundation/uzi-did-x509-issuer/x509_cert"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -65,6 +66,13 @@ func TestDefaultDidCreator_CreateDid(t *testing.T) {
 // TestDefaultDidCreator_ParseDid tests the ParseDid function of DefaultDidProcessor by providing different DID strings.
 // It checks for correct X509Did parsing and appropriate error messages.
 func TestDefaultDidCreator_ParseDid(t *testing.T) {
+	policies := []*x509_cert.OtherNameValue{
+		{
+			PolicyType: "san",
+			Type:       "otherName",
+			Value:      "A_BIG_STRING",
+		},
+	}
 	type fields struct {
 	}
 	type args struct {
@@ -95,7 +103,7 @@ func TestDefaultDidCreator_ParseDid(t *testing.T) {
 			name:   "Happy path",
 			fields: fields{},
 			args:   args{didString: "did:x509:0:sha512:hash::san:otherName:A_BIG_STRING"},
-			want:   &X509Did{Version: "0", RootCertificateHashAlg: "sha512", RootCertificateHash: "hash", SanType: "otherName", Ura: "A_BIG_STRING"},
+			want:   &X509Did{Version: "0", RootCertificateHashAlg: "sha512", RootCertificateHash: "hash", Policies: policies},
 			errMsg: "",
 		},
 	}
@@ -116,8 +124,7 @@ func TestDefaultDidCreator_ParseDid(t *testing.T) {
 				(tt.want.Version != got.Version ||
 					tt.want.RootCertificateHashAlg != got.RootCertificateHashAlg ||
 					tt.want.RootCertificateHash != got.RootCertificateHash ||
-					tt.want.SanType != got.SanType ||
-					tt.want.Ura != got.Ura) {
+					!reflect.DeepEqual(tt.want.Policies, got.Policies)) {
 				t.Errorf("DefaultDidProcessor.ParseDid() = %v, want = %v", got, tt.want)
 			}
 		})

--- a/did_x509/did_x509_test.go
+++ b/did_x509/did_x509_test.go
@@ -11,13 +11,13 @@ import (
 
 // TestDefaultDidCreator_CreateDid tests the CreateDid function of DefaultDidProcessor by providing different certificate chains.
 // It checks for correct DID generation and appropriate error messages.
-func TestDefaultDidCreator_CreateDid(t *testing.T) {
+func TestDefaultDidCreator_CreateDidSingle(t *testing.T) {
 	type fields struct {
 	}
 	type args struct {
 		chain []*x509.Certificate
 	}
-	chain, _, rootCert, _, _, err := x509_cert.BuildSelfSignedCertChain("A_BIG_STRING")
+	chain, _, rootCert, _, _, err := x509_cert.BuildSelfSignedCertChain("A_BIG_STRING", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,6 +40,57 @@ func TestDefaultDidCreator_CreateDid(t *testing.T) {
 			fields: fields{},
 			args:   args{chain: chain},
 			want:   strings.Join([]string{"did", "x509", "0", alg, rootHashString, "", "san", "otherName", "A_BIG_STRING"}, ":"),
+			errMsg: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateDid(tt.args.chain[0], tt.args.chain[len(tt.args.chain)-1])
+			wantErr := tt.errMsg != ""
+			if (err != nil) != wantErr {
+				t.Errorf("DefaultDidProcessor.CreateDid() error = %v, errMsg %v", err, tt.errMsg)
+				return
+			} else if wantErr {
+				if err.Error() != tt.errMsg {
+					t.Errorf("DefaultDidProcessor.CreateDid() expected = \"%v\", got: \"%v\"", tt.errMsg, err.Error())
+				}
+			}
+
+			if got != tt.want {
+				t.Errorf("DefaultDidProcessor.CreateDid() = \n%v\n, want: \n%v\n", got, tt.want)
+			}
+		})
+	}
+}
+func TestDefaultDidCreator_CreateDidDouble(t *testing.T) {
+	type fields struct {
+	}
+	type args struct {
+		chain []*x509.Certificate
+	}
+	chain, _, rootCert, _, _, err := x509_cert.BuildSelfSignedCertChain("A_BIG_STRING", "A_SMALL_STRING")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alg := "sha512"
+	hash, err := x509_cert.Hash(rootCert.Raw, alg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootHashString := base64.RawURLEncoding.EncodeToString(hash)
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+		errMsg string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{},
+			args:   args{chain: chain},
+			want:   strings.Join([]string{"did", "x509", "0", alg, rootHashString, "", "san", "otherName", "A_BIG_STRING", "", "san", "permanentIdentifier.value", "A_SMALL_STRING", "", "san", "permanentIdentifier.assigner", "2.16.528.1.1007.3.3"}, ":"),
 			errMsg: "",
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nuts-foundation/uzi-did-x509-issuer
 go 1.23.1
 
 require (
-	github.com/alecthomas/kong v1.2.1
+	github.com/alecthomas/kong v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/huandu/go-clone v1.7.2
 	github.com/lestrrat-go/jwx/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/huandu/go-clone v1.7.2
-	github.com/lestrrat-go/jwx/v2 v2.1.1
+	github.com/lestrrat-go/jwx/v2 v2.1.2
 	github.com/nuts-foundation/go-did v0.15.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/lestrrat-go/httprc v1.0.6 h1:qgmgIRhpvBqexMJjA/PmwSvhNk679oqD1RbovdCG
 github.com/lestrrat-go/httprc v1.0.6/go.mod h1:mwwz3JMTPBjHUkkDv/IGJ39aALInZLrhBp0X7KGUZlo=
 github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
-github.com/lestrrat-go/jwx/v2 v2.1.1 h1:Y2ltVl8J6izLYFs54BVcpXLv5msSW4o8eXwnzZLI32E=
-github.com/lestrrat-go/jwx/v2 v2.1.1/go.mod h1:4LvZg7oxu6Q5VJwn7Mk/UwooNRnTHUpXBj2C4j3HNx0=
+github.com/lestrrat-go/jwx/v2 v2.1.2 h1:6poete4MPsO8+LAEVhpdrNI4Xp2xdiafgl2RD89moBc=
+github.com/lestrrat-go/jwx/v2 v2.1.2/go.mod h1:pO+Gz9whn7MPdbsqSJzG8TlEpMZCwQDXnFJ+zsUVh8Y=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/mr-tron/base58 v1.1.0 h1:Y51FGVJ91WBqCEabAi5OPUz38eAx8DakuAm5svLcsfQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
-github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.2.1 h1:E8jH4Tsgv6wCRX2nGrdPyHDUCSG83WH2qE4XLACD33Q=
-github.com/alecthomas/kong v1.2.1/go.mod h1:rKTSFhbdp3Ryefn8x5MOEprnRFQ7nlmMC01GKhehhBM=
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v1.3.0 h1:YJKuU6/TV2XOBtymafSeuzDvLAFR8cYMZiXVNLhAO6g=
+github.com/alecthomas/kong v1.3.0/go.mod h1:IDc8HyiouDdpdiEiY81iaEJM8rSIW6LzX8On4FCO0bE=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 		// 2.16.528.1.1007.99.2110-1-<UZI-nr>-S-<Abonnee-nr>-00.000-<AGB-code>
 		otherName := fmt.Sprintf("2.16.528.1.1007.99.2110-1-%s-S-%s-00.000-%s", cli.TestCert.Uzi, cli.TestCert.Ura, cli.TestCert.Agb)
 		fmt.Println("Building certificate chain for identifier:", otherName)
-		chain, _, _, privKey, _, err := x509_cert.BuildSelfSignedCertChain(otherName)
+		chain, _, _, privKey, _, err := x509_cert.BuildSelfSignedCertChain(otherName, cli.TestCert.Ura)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(-1)

--- a/pem/pem_reader_test.go
+++ b/pem/pem_reader_test.go
@@ -59,7 +59,7 @@ func TestParseFileOrPath(t *testing.T) {
 				log.Fatal(err)
 			}
 		}(file.Name())
-		certs, chainPem, _, _, _, err := x509_cert.BuildSelfSignedCertChain("A BIG STRING")
+		certs, chainPem, _, _, _, err := x509_cert.BuildSelfSignedCertChain("A BIG STRING", "a small one")
 		failError(t, err)
 		for i := 0; i < chainPem.Len(); i++ {
 			certBlock, ok := chainPem.Get(i)
@@ -86,7 +86,7 @@ func TestParseFileOrPath(t *testing.T) {
 
 	})
 	t.Run("Happy flow directory", func(t *testing.T) {
-		certs, chainPem, _, _, _, err := x509_cert.BuildSelfSignedCertChain("A BIG STRING")
+		certs, chainPem, _, _, _, err := x509_cert.BuildSelfSignedCertChain("A BIG STRING", "a small one")
 		failError(t, err)
 		tempDir, _ := os.MkdirTemp("", "example")
 		defer func(path string) {

--- a/uzi_vc_issuer/ura_issuer.go
+++ b/uzi_vc_issuer/ura_issuer.go
@@ -118,7 +118,7 @@ func BuildUraVerifiableCredential(chain []*x509.Certificate, signingKey *rsa.Pri
 	if uzi != serialNumber {
 		return nil, errors.New("serial number does not match UZI number")
 	}
-	template, err := uraCredential(did, otherNameValues, serialNumber, subjectDID)
+	template, err := uraCredential(did, otherNameValues, subjectDID)
 	if err != nil {
 		return nil, err
 	}
@@ -263,25 +263,23 @@ func convertHeaders(headers map[string]interface{}) (jws.Headers, error) {
 
 // uraCredential generates a VerifiableCredential for a given URA and UZI number, including the subject's DID.
 // It sets a 1-year expiration period from the current issuance date.
-func uraCredential(issuer string, otherNameValues []*x509_cert.OtherNameValue, serialNumber string, subjectDID string) (*vc.VerifiableCredential, error) {
+func uraCredential(issuer string, otherNameValues []*x509_cert.OtherNameValue, subjectDID string) (*vc.VerifiableCredential, error) {
 	exp := time.Now().Add(time.Hour * 24 * 365 * 100)
 	iat := time.Now()
-	stringValue, err := x509_cert.FindOtherNameValue(otherNameValues, x509_cert.PolicyTypeSan, x509_cert.SanTypeOtherName)
-	if err != nil {
-		return nil, err
+	subject := map[x509_cert.SanTypeName]interface{}{
+		"id": subjectDID,
 	}
+	for _, otherNameValue := range otherNameValues {
+		subject[otherNameValue.Type] = otherNameValue.Value
+	}
+
 	return &vc.VerifiableCredential{
-		Issuer:         ssi.MustParseURI(issuer),
-		Context:        []ssi.URI{ssi.MustParseURI("https://www.w3.org/2018/credentials/v1")},
-		Type:           []ssi.URI{ssi.MustParseURI("VerifiableCredential"), ssi.MustParseURI("UziServerCertificateCredential")},
-		ID:             func() *ssi.URI { id := ssi.MustParseURI(uuid.NewString()); return &id }(),
-		IssuanceDate:   iat,
-		ExpirationDate: &exp,
-		CredentialSubject: []interface{}{
-			map[string]interface{}{
-				"id":        subjectDID,
-				"otherName": stringValue,
-			},
-		},
+		Issuer:            ssi.MustParseURI(issuer),
+		Context:           []ssi.URI{ssi.MustParseURI("https://www.w3.org/2018/credentials/v1")},
+		Type:              []ssi.URI{ssi.MustParseURI("VerifiableCredential"), ssi.MustParseURI("UziServerCertificateCredential")},
+		ID:                func() *ssi.URI { id := ssi.MustParseURI(uuid.NewString()); return &id }(),
+		IssuanceDate:      iat,
+		ExpirationDate:    &exp,
+		CredentialSubject: []interface{}{subject},
 	}, nil
 }

--- a/uzi_vc_issuer/ura_issuer_test.go
+++ b/uzi_vc_issuer/ura_issuer_test.go
@@ -59,7 +59,7 @@ func TestBuildUraVerifiableCredential(t *testing.T) {
 				certs[0] = cert
 				return certs, privateKey, "did:example:123"
 			},
-			errorText: "no otherName found in the SAN attributes, please check if the certificate is an UZI Server Certificate",
+			errorText: "no values found in the SAN attributes, please check if the certificate is an UZI Server Certificate",
 		},
 		{
 			name: "invalid serial number",
@@ -77,7 +77,7 @@ func TestBuildUraVerifiableCredential(t *testing.T) {
 				certs[0] = &x509.Certificate{}
 				return certs, privateKey, "did:example:123"
 			},
-			errorText: "no otherName found in the SAN attributes, please check if the certificate is an UZI Server Certificate",
+			errorText: "no values found in the SAN attributes, please check if the certificate is an UZI Server Certificate",
 		},
 		{
 			name: "broken signing key",

--- a/uzi_vc_issuer/ura_issuer_test.go
+++ b/uzi_vc_issuer/ura_issuer_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestBuildUraVerifiableCredential(t *testing.T) {
 
-	_certs, _, _, privateKey, signingCert, err := x509_cert.BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344")
+	_certs, _, _, privateKey, signingCert, err := x509_cert.BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "90000380")
 	failError(t, err)
 
 	tests := []struct {
@@ -38,7 +38,7 @@ func TestBuildUraVerifiableCredential(t *testing.T) {
 		{
 			name: "invalid signing certificate 1",
 			in: func(certs []*x509.Certificate) ([]*x509.Certificate, *rsa.PrivateKey, string) {
-				signingTmpl, err := x509_cert.SigningCertTemplate(nil, "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344")
+				signingTmpl, err := x509_cert.SigningCertTemplate(nil, "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "90000380")
 				signingTmpl.Subject.SerialNumber = "KAAS"
 				failError(t, err)
 				cert, _, err := x509_cert.CreateCert(signingTmpl, signingCert, signingCert.PublicKey, privateKey)
@@ -51,7 +51,7 @@ func TestBuildUraVerifiableCredential(t *testing.T) {
 		{
 			name: "invalid signing certificate 2",
 			in: func(certs []*x509.Certificate) ([]*x509.Certificate, *rsa.PrivateKey, string) {
-				signingTmpl, err := x509_cert.SigningCertTemplate(nil, "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344")
+				signingTmpl, err := x509_cert.SigningCertTemplate(nil, "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "90000380")
 				signingTmpl.ExtraExtensions = make([]pkix.Extension, 0)
 				failError(t, err)
 				cert, _, err := x509_cert.CreateCert(signingTmpl, signingCert, signingCert.PublicKey, privateKey)
@@ -112,7 +112,7 @@ func TestBuildUraVerifiableCredential(t *testing.T) {
 }
 
 func TestBuildCertificateChain(t *testing.T) {
-	certs, _, _, _, _, err := x509_cert.BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344")
+	certs, _, _, _, _, err := x509_cert.BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "90000380")
 	failError(t, err)
 	tests := []struct {
 		name      string
@@ -227,10 +227,11 @@ func TestBuildCertificateChain(t *testing.T) {
 
 func TestIssue(t *testing.T) {
 
-	brokenChain, _, _, _, _, err := x509_cert.BuildSelfSignedCertChain("KAAS")
+	brokenChain, _, _, _, _, err := x509_cert.BuildSelfSignedCertChain("KAAS", "HAM")
 	failError(t, err)
 	identifier := "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344"
-	chain, _, rootCert, privKey, _, err := x509_cert.BuildSelfSignedCertChain(identifier)
+	ura := "90000380"
+	chain, _, rootCert, privKey, _, err := x509_cert.BuildSelfSignedCertChain(identifier, ura)
 	bytesRootHash := sha512.Sum512(rootCert.Raw)
 	rootHash := base64.RawURLEncoding.EncodeToString(bytesRootHash[:])
 	failError(t, err)
@@ -286,7 +287,7 @@ func TestIssue(t *testing.T) {
 			allowTest:  true,
 			out: &vc.VerifiableCredential{
 				Context: []ssi.URI{ssi.MustParseURI("https://www.w3.org/2018/credentials/v1")},
-				Issuer:  did.MustParseDID(fmt.Sprintf("did:x509:0:sha512:%s::san:otherName:%s", rootHash, identifier)).URI(),
+				Issuer:  did.MustParseDID(fmt.Sprintf("did:x509:0:sha512:%s::san:otherName:%s::san:permanentIdentifier.value:%s::san:permanentIdentifier.assigner:%s", rootHash, identifier, ura, x509_cert.UraAssigner.String())).URI(),
 				Type:    []ssi.URI{ssi.MustParseURI("VerifiableCredential"), ssi.MustParseURI("UziServerCertificateCredential")},
 			},
 			errorText: "",

--- a/x509_cert/x509_cert.go
+++ b/x509_cert/x509_cert.go
@@ -103,8 +103,8 @@ func FixChainHeaders(chain *cert.Chain) (*cert.Chain, error) {
 	return rv, nil
 }
 
-func ParseUraFromOtherNameValue(value string) (uzi string, ura string, agb string, err error) {
-	submatch := RegexOtherNameValue.FindStringSubmatch(value)
+func ParseUraFromOtherNameValue(stringValue string) (uzi string, ura string, agb string, err error) {
+	submatch := RegexOtherNameValue.FindStringSubmatch(stringValue)
 	if len(submatch) < 4 {
 		return "", "", "", errors.New("failed to parse URA from OtherNameValue")
 	}

--- a/x509_cert/x509_cert_test.go
+++ b/x509_cert/x509_cert_test.go
@@ -74,7 +74,7 @@ func TestHash(t *testing.T) {
 	}
 }
 func TestParseChain(t *testing.T) {
-	_, chainPem, _, _, _, err := BuildSelfSignedCertChain("9907878")
+	_, chainPem, _, _, _, err := BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "900030787")
 	failError(t, err)
 	derChains := make([][]byte, chainPem.Len())
 	for i := 0; i < chainPem.Len(); i++ {
@@ -118,7 +118,7 @@ func TestParseChain(t *testing.T) {
 }
 
 func TestParsePrivateKey(t *testing.T) {
-	_, _, _, privateKey, _, err := BuildSelfSignedCertChain("9907878")
+	_, _, _, privateKey, _, err := BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "900030787")
 	failError(t, err)
 	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
 	failError(t, err)

--- a/x509_cert/x509_utils.go
+++ b/x509_cert/x509_utils.go
@@ -59,6 +59,15 @@ func FindSanTypes(certificate *x509.Certificate) ([]*OtherNameValue, error) {
 	return rv, nil
 }
 
+func FindOtherNameValue(value []*OtherNameValue, policyType PolicyType, sanTypeName SanTypeName) (string, error) {
+	for _, v := range value {
+		if v != nil && v.PolicyType == policyType && v.Type == sanTypeName {
+			return v.Value, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find value for policyType: %s and sanTypeName: %s", policyType, sanTypeName)
+}
+
 func findOtherNameValue(cert *x509.Certificate) (string, error) {
 	value := ""
 	for _, extension := range cert.Extensions {

--- a/x509_cert/x509_utils_test.go
+++ b/x509_cert/x509_utils_test.go
@@ -2,27 +2,42 @@ package x509_cert
 
 import (
 	"crypto/x509"
+	"reflect"
 	"testing"
 )
 
 func TestFindOtherName(t *testing.T) {
-	chain, _, _, _, _, err := BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344")
+	chain, _, _, _, _, err := BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "90000380")
 	if err != nil {
 		t.Fatal(err)
 	}
 	tests := []struct {
 		name        string
 		certificate *x509.Certificate
-		wantName    string
-		wantType    SanTypeName
+		want        []*OtherNameValue
 		wantErr     bool
 	}{
 		{
 			name:        "ValidOtherName",
 			certificate: chain[0],
-			wantName:    "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344",
-			wantType:    SanTypeOtherName,
-			wantErr:     false,
+			want: []*OtherNameValue{
+				{
+					PolicyType: PolicyTypeSan,
+					Type:       SanTypeOtherName,
+					Value:      "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344",
+				},
+				{
+					PolicyType: PolicyTypeSan,
+					Type:       SanTypePermanentIdentifierValue,
+					Value:      "90000380",
+				},
+				{
+					PolicyType: PolicyTypeSan,
+					Type:       SanTypePermanentIdentifierAssigner,
+					Value:      UraAssigner.String(),
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name:        "NoOtherName",
@@ -43,14 +58,8 @@ func TestFindOtherName(t *testing.T) {
 				return
 			}
 			if otherNames != nil {
-				nameValues := otherNames
-				gotName := nameValues[0].Value
-				if gotName != tt.wantName {
-					t.Errorf("FindSanTypes() gotName = %v, want %v", gotName, tt.wantName)
-				}
-				gotType := nameValues[0].Type
-				if gotType != tt.wantType {
-					t.Errorf("FindSanTypes() gotType = %v, want %v", gotType, tt.wantType)
+				if !reflect.DeepEqual(otherNames, tt.want) {
+					t.Errorf("FindSanTypes() got = %v, want %v", otherNames, tt.want)
 				}
 			} else if !tt.wantErr {
 				t.Errorf("unexpected nil from otherNames")

--- a/x509_cert/x509_utils_test.go
+++ b/x509_cert/x509_utils_test.go
@@ -21,7 +21,7 @@ func TestFindOtherName(t *testing.T) {
 			name:        "ValidOtherName",
 			certificate: chain[0],
 			wantName:    "2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344",
-			wantType:    SAN_TYPE_OTHER_NAME,
+			wantType:    SanTypeOtherName,
 			wantErr:     false,
 		},
 		{
@@ -37,16 +37,23 @@ func TestFindOtherName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotName, gotType, err := FindOtherName(tt.certificate)
+			otherNames, err := FindSanTypes(tt.certificate)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FindOtherName() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FindSanTypes() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if gotName != tt.wantName {
-				t.Errorf("FindOtherName() gotName = %v, want %v", gotName, tt.wantName)
-			}
-			if gotType != tt.wantType {
-				t.Errorf("FindOtherName() gotType = %v, want %v", gotType, tt.wantType)
+			if otherNames != nil {
+				nameValues := otherNames
+				gotName := nameValues[0].Value
+				if gotName != tt.wantName {
+					t.Errorf("FindSanTypes() gotName = %v, want %v", gotName, tt.wantName)
+				}
+				gotType := nameValues[0].Type
+				if gotType != tt.wantType {
+					t.Errorf("FindSanTypes() gotType = %v, want %v", gotType, tt.wantType)
+				}
+			} else if !tt.wantErr {
+				t.Errorf("unexpected nil from otherNames")
 			}
 		})
 	}


### PR DESCRIPTION
Replaced the single `otherName` SAN type detection with a more flexible approach that supports multiple SAN types and policies. Updated the respective functions and tests to accommodate this change, ensuring backward compatibility and improved error handling.