### PR TITLE
BUGFIX: Add buffered output for JWT printing

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/alecthomas/kong"
 	"github.com/nuts-foundation/uzi-did-x509-issuer/uzi_vc_issuer"
@@ -93,9 +94,24 @@ func main() {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		println(jwt)
+		printLineAndFlush(jwt)
 	default:
 		fmt.Println("Unknown command")
+		os.Exit(-1)
+	}
+}
+
+// printLineAndFlush writes a JWT (JSON Web Token) to the standard output and flushes the buffered writer.
+func printLineAndFlush(jwt string) {
+	f := bufio.NewWriter(os.Stdout)
+	// Make sure to flush
+	defer func(f *bufio.Writer) {
+		_ = f.Flush()
+	}(f)
+	// Write the JWT
+	_, err := f.WriteString(jwt + "\n")
+	if err != nil {
+		fmt.Println(err)
 		os.Exit(-1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,11 @@ func main() {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		println(jwt)
+		err = printLineAndFlush(jwt)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 	case "test-cert <uzi> <ura> <agb>", "test-cert <uzi> <ura> <agb> <subject_did>":
 		// Format is 2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344
 		// <OID CA>-<versie-nr>-<UZI-nr>-<pastype>-<Abonnee-nr>-<rol>-<AGB-code>
@@ -94,7 +98,11 @@ func main() {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		printLineAndFlush(jwt)
+		err = printLineAndFlush(jwt)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 	default:
 		fmt.Println("Unknown command")
 		os.Exit(-1)
@@ -102,7 +110,7 @@ func main() {
 }
 
 // printLineAndFlush writes a JWT (JSON Web Token) to the standard output and flushes the buffered writer.
-func printLineAndFlush(jwt string) {
+func printLineAndFlush(jwt string) error {
 	f := bufio.NewWriter(os.Stdout)
 	// Make sure to flush
 	defer func(f *bufio.Writer) {
@@ -110,10 +118,7 @@ func printLineAndFlush(jwt string) {
 	}(f)
 	// Write the JWT
 	_, err := f.WriteString(jwt + "\n")
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+	return err
 }
 
 func issueVc(vc VC) (string, error) {

--- a/uzi_vc_issuer/ura_issuer.go
+++ b/uzi_vc_issuer/ura_issuer.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -77,14 +76,8 @@ func Issue(certificateFile string, signingKeyFile string, subjectDID string, all
 	if err != nil {
 		return "", err
 	}
-	credentialJSON, err := json.Marshal(credential)
-	if err != nil {
-		return "", err
-	}
+	jwtString := credential.Raw()
 	validator := uzi_vc_validator.NewUraValidator(allowTestUraCa, allowSelfSignedCa)
-	jwtString := string(credentialJSON)
-	jwtString = jwtString[1:]                // Chop start
-	jwtString = jwtString[:len(jwtString)-1] // Chop end
 	err = validator.Validate(jwtString)
 	if err != nil {
 		return "", err

--- a/uzi_vc_validator/ura_validator.go
+++ b/uzi_vc_validator/ura_validator.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"github.com/lestrrat-go/jwx/v2/cert"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -38,9 +37,7 @@ type JwtHeaderValues struct {
 }
 
 func (u UraValidatorImpl) Validate(jwtString string) error {
-	credential := &vc.VerifiableCredential{}
-	marshal, _ := json.Marshal(jwtString)
-	err := json.Unmarshal(marshal, credential)
+	credential, err := vc.ParseVerifiableCredential(jwtString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Replaced println with a buffered writer when outputting the JWT to ensure the output is properly flushed. Introduced a new helper function `printLineAndFlush` to handle the buffered writing and flushing process.