### PR TITLE
Use sha256 instead of sha512

### DIFF
--- a/uzi_vc_issuer/ura_issuer_test.go
+++ b/uzi_vc_issuer/ura_issuer_test.go
@@ -187,7 +187,7 @@ func TestIssue(t *testing.T) {
 		assert.Equal(t, "https://www.w3.org/2018/credentials/v1", vc.Context[0].String())
 		assert.True(t, vc.IsType(ssi.MustParseURI("VerifiableCredential")))
 		assert.True(t, vc.IsType(ssi.MustParseURI("X509Credential")))
-		assert.Equal(t, "did:x509:0:sha512:0OXDVLevEnf_sE-Ayopm0Yof_gmBwxwKZmzbDhKeAwj9vcsI_Q14TBArYsCftQTABLM-Vx9BB6zI05Me2aksaA::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare", vc.Issuer.String())
+		assert.Equal(t, "did:x509:0:sha256:IzvPueXLRjJtLtIicMzV3icpiLQPemu8lBv6oRGjm-o::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare", vc.Issuer.String())
 
 		expectedCredentialSubject := []interface{}([]interface{}{map[string]interface{}{
 			"id":                           "did:example:123",
@@ -210,7 +210,7 @@ func TestIssue(t *testing.T) {
 
 		vc, err := Issue(validChain, validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization))
 
-		assert.Equal(t, "did:x509:0:sha512:0OXDVLevEnf_sE-Ayopm0Yof_gmBwxwKZmzbDhKeAwj9vcsI_Q14TBArYsCftQTABLM-Vx9BB6zI05Me2aksaA::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare%20%26%20Co", vc.Issuer.String())
+		assert.Equal(t, "did:x509:0:sha256:IzvPueXLRjJtLtIicMzV3icpiLQPemu8lBv6oRGjm-o::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare%20%26%20Co", vc.Issuer.String())
 	})
 
 }

--- a/x509_cert/x509_cert.go
+++ b/x509_cert/x509_cert.go
@@ -2,17 +2,14 @@ package x509_cert
 
 import (
 	"crypto/rsa"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"github.com/lestrrat-go/jwx/v2/cert"
-	"golang.org/x/crypto/sha3"
 	"regexp"
 	"strings"
+
+	"github.com/lestrrat-go/jwx/v2/cert"
 )
 
 // SubjectAlternativeNameType represents the ASN.1 Object Identifier for Subject Alternative Name.
@@ -27,27 +24,6 @@ var (
 // e.g.: 1-123456789-S-88888801-00.000-12345678
 // var RegexOtherNameValue = regexp.MustCompile(`2\.16\.528\.1\.1007.\d+\.\d+-\d+-\d+-S-(\d+)-00\.000-\d+`)
 var RegexOtherNameValue = regexp.MustCompile(`^[0-9.]+-\d+-(\d+)-S-(\d+)-00\.000-(\d+)$`)
-
-// Hash computes the hash of the input data using the specified algorithm.
-// Supported algorithms include "sha1", "sha256", "sha384", and "sha512".
-// Returns the computed hash as a byte slice or an error if the algorithm is not supported.
-func Hash(data []byte, alg string) ([]byte, error) {
-	switch alg {
-	case "sha1":
-		sum := sha1.Sum(data)
-		return sum[:], nil
-	case "sha256":
-		sum := sha256.Sum256(data)
-		return sum[:], nil
-	case "sha384":
-		sum := sha3.Sum384(data)
-		return sum[:], nil
-	case "sha512":
-		sum := sha512.Sum512(data)
-		return sum[:], nil
-	}
-	return nil, fmt.Errorf("unsupported hash algorithm: %s", alg)
-}
 
 // ParseCertificates parses a slice of DER-encoded byte arrays into a slice of x509.Certificate.
 // It returns an error if any of the certificates cannot be parsed.

--- a/x509_cert/x509_cert_test.go
+++ b/x509_cert/x509_cert_test.go
@@ -1,78 +1,14 @@
 package x509_cert
 
 import (
-	"bytes"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/sha3"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestHash(t *testing.T) {
-	sha1sum := sha1.Sum([]byte("test"))
-	sha256sum := sha256.Sum256([]byte("test"))
-	sha384sum := sha3.Sum384([]byte("test"))
-	sha512sum := sha512.Sum512([]byte("test"))
-	testCases := []struct {
-		name  string
-		data  []byte
-		alg   string
-		hash  []byte
-		error error
-	}{
-		{
-			name: "SHA1",
-			data: []byte("test"),
-			alg:  "sha1",
-			hash: sha1sum[:],
-		},
-		{
-			name: "SHA256",
-			data: []byte("test"),
-			alg:  "sha256",
-			hash: sha256sum[:],
-		},
-		{
-			name: "SHA384",
-			data: []byte("test"),
-			alg:  "sha384",
-			hash: sha384sum[:],
-		},
-		{
-			name: "SHA512",
-			data: []byte("test"),
-			alg:  "sha512",
-			hash: sha512sum[:],
-		},
-		{
-			name:  "Unsupported",
-			data:  []byte("test"),
-			alg:   "unsupported",
-			hash:  nil,
-			error: fmt.Errorf("unsupported hash algorithm: %s", "unsupported"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			hash, err := Hash(tc.data, tc.alg)
-			if tc.error != nil {
-				if err.Error() != tc.error.Error() {
-					t.Errorf("unexpected error %v, want %v", err, tc.error)
-				}
-			}
-			if !bytes.Equal(hash, tc.hash) {
-				t.Errorf("unexpected hash %x, want %x", hash, tc.hash)
-			}
-		})
-	}
-}
 func TestParseChain(t *testing.T) {
 	_, chainPem, _, _, _, err := BuildSelfSignedCertChain("2.16.528.1.1007.99.2110-1-900030787-S-90000380-00.000-11223344", "900030787")
 	failError(t, err)


### PR DESCRIPTION
Fix #26 

* Move the `Hash` function to the `did_x509`package where it's used.
* Make hash alg a constant
* Use PS256 instead of PS512 for signing
* use `did.DID` type for the subject instead of a string