### PR TITLE
Refactor credential subject structure

### DIFF
--- a/uzi_vc_issuer/ura_issuer.go
+++ b/uzi_vc_issuer/ura_issuer.go
@@ -410,12 +410,20 @@ func uraCredential(issuerDID did.DID, expirationDate time.Time, otherNameValues 
 	subject := map[string]interface{}{
 		"id": subjectDID,
 	}
+	var otherNameMap = map[string]string{}
 	for _, otherNameValue := range otherNameValues {
-		subject[string(otherNameValue.Type)] = otherNameValue.Value
+		otherNameMap[string(otherNameValue.Type)] = otherNameValue.Value
+	}
+	if len(otherNameMap) > 0 {
+		subject[string(x509_cert.PolicyTypeSan)] = otherNameMap
 	}
 
+	var subjectMap = map[string]string{}
 	for _, subjectType := range subjectTypes {
-		subject[string(subjectType.Type)] = subjectType.Value
+		subjectMap[string(subjectType.Type)] = subjectType.Value
+	}
+	if len(subjectMap) > 0 {
+		subject[string(x509_cert.PolicyTypeSubject)] = subjectMap
 	}
 
 	id := did.DIDURL{

--- a/uzi_vc_issuer/ura_issuer_test.go
+++ b/uzi_vc_issuer/ura_issuer_test.go
@@ -190,11 +190,15 @@ func TestIssue(t *testing.T) {
 		assert.Equal(t, "did:x509:0:sha256:IzvPueXLRjJtLtIicMzV3icpiLQPemu8lBv6oRGjm-o::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare", vc.Issuer.String())
 
 		expectedCredentialSubject := []interface{}([]interface{}{map[string]interface{}{
-			"id":                           "did:example:123",
-			"O":                            "FauxCare",
-			"otherName":                    "2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333",
-			"permanentIdentifier.assigner": "2.16.528.1.1007.3.3",
-			"permanentIdentifier.value":    "2222222",
+			"id": "did:example:123",
+			"subject": map[string]interface{}{
+				"O": "FauxCare",
+			},
+			"san": map[string]interface{}{
+				"otherName":                    "2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333",
+				"permanentIdentifier.assigner": "2.16.528.1.1007.3.3",
+				"permanentIdentifier.value":    "2222222",
+			},
 		}})
 
 		assert.Equal(t, expectedCredentialSubject, vc.CredentialSubject)


### PR DESCRIPTION
Updated the credential subject mapping in `ura_issuer.go` and related tests to use nested structures for "san" and "subject" fields. This enhances readability and better organizes data for more consistent processing.